### PR TITLE
Loc additions

### DIFF
--- a/tnasm/parser.cpp
+++ b/tnasm/parser.cpp
@@ -428,7 +428,8 @@ bool p_code_2_line() {
     shared_ptr <tny_word> immed;
     int save = tnext;
     if((oper = p_code_2_inst()) && (dreg = term(T_REGISTER)) && term(T_COMMA) &&
-       (sreg = term(T_REGISTER)) && (sign = p_plus_or_minus()) && (immed = p_immediate())) {
+       (sreg = term(T_REGISTER)) && (sign = p_plus_or_minus()) && (immed = p_immediate()) &&
+       term(T_EOL)) {
 
         instruction inst;
         inst.line_no = dreg->line_no;
@@ -462,7 +463,8 @@ bool p_code_3_line() {
     shared_ptr <token> dreg, oper;
     shared_ptr <tny_word> immed;
     int save = tnext;
-    if((oper = p_code_3_inst()) && (dreg = term(T_REGISTER)) && term(T_COMMA) && (immed = p_immediate())) {
+    if((oper = p_code_3_inst()) && (dreg = term(T_REGISTER)) && term(T_COMMA) && (immed = p_immediate()) &&
+        term(T_EOL)) {
 
         instruction inst;
         inst.line_no = dreg->line_no;

--- a/tnasm/parser.cpp
+++ b/tnasm/parser.cpp
@@ -510,6 +510,10 @@ bool p_code_4_line() {
         f.instruction.teeny = 1;
         f.instruction.reg1 = dreg->value.u;
 
+        //these are not used need a decision about how to set these to a predictable value
+        f.instruction.reg2 = 0;
+        f.instruction.immed4 = 0;
+
         if(pass == 2) {
             bin_words.push_back(f);
         }

--- a/tnasm/parser.cpp
+++ b/tnasm/parser.cpp
@@ -42,6 +42,7 @@ bool p_code_1_line();
 bool p_code_2_line();
 bool p_code_3_line();
 bool p_code_4_line();
+bool p_code_5_line();
 
 tny_uword token_to_opcode(int id);
 
@@ -155,7 +156,8 @@ bool p_loc() {
            (tnext = save, p_code_1_line())   ||
            (tnext = save, p_code_2_line())   ||
            (tnext = save, p_code_3_line())   ||
-           (tnext = save, p_code_4_line());
+           (tnext = save, p_code_4_line())   ||
+           (tnext = save, p_code_5_line());
 }
 
 /*
@@ -507,6 +509,36 @@ bool p_code_4_line() {
         f.instruction.opcode = token_to_opcode(oper->id);
         f.instruction.teeny = 1;
         f.instruction.reg1 = dreg->value.u;
+
+        if(pass == 2) {
+            bin_words.push_back(f);
+        }
+
+        address += 1;
+        result = true;
+    }
+
+    return result;
+}
+
+/*
+ * code_5_line ::= code_5_inst REGISTER.
+ */
+bool p_code_5_line() {
+    bool result = false;
+    shared_ptr <token> dreg, oper;
+    int save = tnext;
+    if((oper = p_code_5_inst()) && (dreg = term(T_REGISTER)) && term(T_EOL)) {
+
+        instruction inst;
+        inst.line_no = dreg->line_no;
+
+        tny_word &f = inst.first;
+        f.instruction.opcode = token_to_opcode(oper->id);
+        f.instruction.teeny = 1;
+        f.instruction.reg1 = dreg->value.u;
+        f.instruction.reg2 = TNY_REG_ZERO;
+        f.instruction.immed4 = 1;
 
         if(pass == 2) {
             bin_words.push_back(f);

--- a/tnasm/parser.cpp
+++ b/tnasm/parser.cpp
@@ -392,8 +392,7 @@ shared_ptr <token> p_plus_or_minus() {
  */
 bool p_code_1_line() {
     bool result = false;
-    shared_ptr <token> dreg, oper, sreg, sign;
-    shared_ptr <tny_word> immed;
+    shared_ptr <token> dreg, oper, sreg;
     int save = tnext;
     if((oper = p_code_1_inst()) && (dreg = term(T_REGISTER)) && term(T_COMMA) &&
        (sreg = term(T_REGISTER)) && term(T_EOL)) {

--- a/tnasm/parser.cpp
+++ b/tnasm/parser.cpp
@@ -486,6 +486,7 @@ bool p_code_2_line() {
         bool make_teeny = is_teeny(inst.second.s);
         if(make_teeny) {
             f.instruction.immed4 = inst.second.s;
+            f.instruction.teeny = true;
             address++;
         }
         else {
@@ -531,6 +532,7 @@ bool p_code_3_line() {
         bool make_teeny = is_teeny(inst.second.s);
         if(make_teeny) {
             f.instruction.immed4 = inst.second.s;
+            f.instruction.teeny = true;
             address++;
         }
         else {

--- a/tnasm/parser.cpp
+++ b/tnasm/parser.cpp
@@ -41,6 +41,7 @@ shared_ptr <token> p_plus_or_minus();
 bool p_code_1_line();
 bool p_code_2_line();
 bool p_code_3_line();
+bool p_code_4_line();
 
 tny_uword token_to_opcode(int id);
 
@@ -153,7 +154,8 @@ bool p_loc() {
            (tnext = save, p_label_line())    ||
            (tnext = save, p_code_1_line())   ||
            (tnext = save, p_code_2_line())   ||
-           (tnext = save, p_code_3_line());
+           (tnext = save, p_code_3_line())   ||
+           (tnext = save, p_code_4_line());
 }
 
 /*
@@ -483,6 +485,34 @@ bool p_code_3_line() {
         }
 
         address += 2;
+        result = true;
+    }
+
+    return result;
+}
+
+/*
+ * code_4_line ::= code_4_inst REGISTER.
+ */
+bool p_code_4_line() {
+    bool result = false;
+    shared_ptr <token> dreg, oper;
+    int save = tnext;
+    if((oper = p_code_4_inst()) && (dreg = term(T_REGISTER)) && term(T_EOL)) {
+
+        instruction inst;
+        inst.line_no = dreg->line_no;
+
+        tny_word &f = inst.first;
+        f.instruction.opcode = token_to_opcode(oper->id);
+        f.instruction.teeny = 1;
+        f.instruction.reg1 = dreg->value.u;
+
+        if(pass == 2) {
+            bin_words.push_back(f);
+        }
+
+        address += 1;
         result = true;
     }
 

--- a/tnasm/test.asm
+++ b/tnasm/test.asm
@@ -7,6 +7,7 @@
 !main
     add r3, r4 + 7
     mod r3, r1
+    neg r1
     OR  SP, rA - 5
     div rE, 15
     xor rA, -17

--- a/tnasm/test.asm
+++ b/tnasm/test.asm
@@ -5,31 +5,33 @@
 ;-------------------
 ; Don't change any of the lines in this boxed section. They are crafted to
 ; demonstrate multipass label resolution is working
-.variable amos 0x74A3
-.variable aero 0xBeeF
+.variable amos 0x74A3 ;1
+.variable aero 0xBeeF ;1
 
 !main
-    add r3, r4 + 7
-    mod r3, r1
-    neg r1
-    inc r2
-    dec r2
-    OR  SP, rA - 5
+    add r3, r4 + 7  ;1
+    mod r3, r1      ;1
+    neg r1          ;1
+    inc r2          ;1
+    dec r2          ;1
+    OR  SP, rA - 5  ;1
 !early
-    div rE, 15
-    xor rA, -17
+    div rE, 15      ;2
+    xor rA, -17     ;2
 !middle
 ;--------------------
 
-    sub PC, PC - !main ;this is an unconditional jmp :-)
+    sub PC, PC - !main  ;1 this is an unconditional jmp :-)
+    str r4 + 16, r3     ;2
+    str r4 + 3, r3      ;1
 
-    123 -15 thirty_one 0x12F_F 0b_110_00000_1011_00_10
+    123 -15 thirty_one 0x12F_F 0b_110_00000_1011_00_10 ;5
 
-    mpy r2, !more
-    SHF rD, r2 - !middle
+    mpy r2, !more           ;2
+    SHF rD, r2 - !middle    ;2
 
 !more
-    BTF r1, r3 + thirty_one
+    BTF r1, r3 + thirty_one ;2
     ;str SP - aero, amos
-    rOt rB, !early
+    rOt rB, !early ;2
 ; and that's all

--- a/tnasm/test.asm
+++ b/tnasm/test.asm
@@ -8,6 +8,8 @@
     add r3, r4 + 7
     mod r3, r1
     neg r1
+    inc r2
+    dec r2
     OR  SP, rA - 5
     div rE, 15
     xor rA, -17

--- a/tnasm/test.asm
+++ b/tnasm/test.asm
@@ -11,9 +11,6 @@
 !main
     add r3, r4 + 7  ;1
     mod r3, r1      ;1
-    neg r1          ;1
-    inc r2          ;1
-    dec r2          ;1
     OR  SP, rA - 5  ;1
 !early
     div rE, 15      ;2
@@ -22,6 +19,10 @@
 ;--------------------
 
     sub PC, PC - !main  ;1 this is an unconditional jmp :-)
+    
+    neg r1              ;1
+    inc r2              ;1
+    dec r2              ;1
     str r4 + 16, r3     ;2
     str r4 + 3, r3      ;1
 


### PR DESCRIPTION
Added code line support through code_6_line.
Got rid of unused variables in my previous code_1_line commit.
Fixed issue where binary did not show shrinkable instructions as teeny.
Added as comments in test.asm the number of tny_words an instruction is expected to take up in the binary this makes it easier to focus in on the instruction you are currently testing. 