### PR TITLE
Corect bit manipulation instructions.  Fixes #36

### DIFF
--- a/teenyat.c
+++ b/teenyat.c
@@ -229,8 +229,8 @@ void tny_clock(teenyat *t) {
 		{
 			tny_sword bit = t->reg[reg2].s + immed;
 			if(bit >= 0 && bit <= 15) {
-				t->reg[reg2].s |= (1 << bit);
-				set_elg_flags(t, t->reg[reg2].s);
+				t->reg[reg1].s |= (1 << bit);
+				set_elg_flags(t, t->reg[reg1].s);
 			}
 		}
 		break;
@@ -238,8 +238,8 @@ void tny_clock(teenyat *t) {
 		{
 			tny_sword bit = t->reg[reg2].s + immed;
 			if(bit >= 0 && bit <= 15) {
-				t->reg[reg2].s &= ~(1 << bit);
-				set_elg_flags(t, t->reg[reg2].s);
+				t->reg[reg1].s &= ~(1 << bit);
+				set_elg_flags(t, t->reg[reg1].s);
 			}
 		}
 		break;
@@ -247,8 +247,8 @@ void tny_clock(teenyat *t) {
 		{
 			tny_sword bit = t->reg[reg2].s + immed;
 			if(bit >= 0 && bit <= 15) {
-				t->reg[reg2].s ^= (1 << bit);
-				set_elg_flags(t, t->reg[reg2].s);
+				t->reg[reg1].s ^= (1 << bit);
+				set_elg_flags(t, t->reg[reg1].s);
 			}
 		}
 		break;


### PR DESCRIPTION
The reg2 field, which is the sreg for these instructions, was being used as the dreg when it should have been the reg1 field.  Fixed.