### PR TITLE
Feature ports

### DIFF
--- a/teenyat.c
+++ b/teenyat.c
@@ -148,6 +148,18 @@ void tny_port_change(teenyat *t, TNY_PORT_CHANGE_FNPTR port_change) {
 	return;
 }
 
+void tny_get_ports(teenyat *t, tny_word *a, tny_word *b) {
+	if(a != NULL) {
+		*a = t->port_a;
+	}
+
+	if(b != NULL) {
+		*b = t->port_b;
+	}
+
+	return;
+}
+
 void tny_clock(teenyat *t) {
 	t->cycle_cnt++;
 

--- a/teenyat.c
+++ b/teenyat.c
@@ -160,6 +160,18 @@ void tny_get_ports(teenyat *t, tny_word *a, tny_word *b) {
 	return;
 }
 
+void tny_set_ports(teenyat *t, tny_word *a, tny_word *b) {
+	if(a != NULL) {
+		tny_modify_port_levels(t, true, *a, true);
+	}
+
+	if(b != NULL) {
+		tny_modify_port_levels(t, true, *b, false);
+	}
+
+	return;
+}
+
 void tny_clock(teenyat *t) {
 	t->cycle_cnt++;
 

--- a/teenyat.c
+++ b/teenyat.c
@@ -172,10 +172,16 @@ void tny_clock(teenyat *t) {
 			tny_uword addr = t->reg[reg2].s + immed;
 			switch(addr) {
 			case TNY_PORTA_ADDRESS:
+				t->reg[reg1] = t->port_a;
+				break;
 			case TNY_PORTB_ADDRESS:
+				t->reg[reg1] = t->port_b;
+				break;
 			case TNY_PORTA_DIR_ADDRESS:
+				t->reg[reg1] = t->port_a_directions;
+				break;
 			case TNY_PORTB_DIR_ADDRESS:
-				/* for the moment, these do nothing */
+				t->reg[reg1] = t->port_b_directions;
 				break;
 			default:
 				if(addr >= TNY_PERIPHERAL_BASE_ADDRESS) {
@@ -213,8 +219,10 @@ void tny_clock(teenyat *t) {
 			case TNY_PORTA_ADDRESS:
 			case TNY_PORTB_ADDRESS:
 			case TNY_PORTA_DIR_ADDRESS:
+				t->port_a_directions = t->reg[reg2];
+				break;
 			case TNY_PORTB_DIR_ADDRESS:
-				/* for the moment, these do nothing */
+				t->port_b_directions = t->reg[reg2];
 				break;
 			default:
 				if(addr >= TNY_PERIPHERAL_BASE_ADDRESS) {

--- a/teenyat.c
+++ b/teenyat.c
@@ -142,6 +142,12 @@ void tny_modify_port_levels(teenyat *t, bool is_system_request, tny_word data, b
 	return;
 }
 
+void tny_port_change(teenyat *t, TNY_PORT_CHANGE_FNPTR port_change) {
+	t->port_change = port_change;
+
+	return;
+}
+
 void tny_clock(teenyat *t) {
 	t->cycle_cnt++;
 

--- a/teenyat.c
+++ b/teenyat.c
@@ -96,6 +96,12 @@ bool tny_reset(teenyat *t) {
 
 	/* "instruction" and "immediate" members do not need initialization */
 
+	/* Initialize ports to output w/ all 0s */
+	t->port_a.u = 0;
+	t->port_a_directions.u = 0;
+	t->port_b.u = 0;
+	t->port_b_directions.u = 0;
+
 	t->delay_cycles = 0;
 	t->cycle_cnt = 0;
 

--- a/teenyat.h
+++ b/teenyat.h
@@ -97,8 +97,16 @@ typedef void(*TNY_WRITE_TO_BUS_FNPTR)(teenyat *t, tny_uword addr, tny_word data,
 typedef void(*TNY_PORT_CHANGE_FNPTR)(teenyat *t, tny_word a, tny_word b);
 
 /** While the TeenyAT has a 16 bit address space, RAM is only 32K words */
-#define TNY_RAM_SIZE (1 << 15)
-#define TNY_MAX_RAM_ADDRESS (TNY_RAM_SIZE - 1)
+#define TNY_RAM_SIZE 0x8000
+#define TNY_MAX_RAM_ADDRESS 0x7FFF
+
+#define TNY_PORTA_DIR_ADDRESS 0x8000
+#define TNY_PORTB_DIR_ADDRESS 0x8001
+#define TNY_PORTA_ADDRESS 0x8002
+#define TNY_PORTB_ADDRESS 0x8003
+
+#define TNY_PERIPHERAL_BASE_ADDRESS 0x9000
+
 #define TNY_BUS_DELAY 3
 
 union tny_word {

--- a/teenyat.h
+++ b/teenyat.h
@@ -88,13 +88,14 @@ typedef void(*TNY_WRITE_TO_BUS_FNPTR)(teenyat *t, tny_uword addr, tny_word data,
  * @param t
  *   The TeenyAT instance making the request
  *
- * @param a
- *   The externally held pin levels for port A
+ * @param is_port_a
+ *   Used to determine whether the levels changed because of a modificatio
+ *   to port A (true) or port B (false).
  *
- * @param b
- *   The externally held pin levels for port B
+ * @param port
+ *   The updated externally held pin levels for the modified port
  */
-typedef void(*TNY_PORT_CHANGE_FNPTR)(teenyat *t, tny_word a, tny_word b);
+typedef void(*TNY_PORT_CHANGE_FNPTR)(teenyat *t, bool is_port_a, tny_word port);
 
 /** While the TeenyAT has a 16 bit address space, RAM is only 32K words */
 #define TNY_RAM_SIZE 0x8000


### PR DESCRIPTION
Implements two 16 bit ports... ports A and B.  From assembly programs, the ports are R/W accessible at 0x8002 and 0x8003.  Control registers to identify the direction of data for each of port A and port B levels are at 0x8000 and 0x8001, where a 0 means output and 1 means input.  Additionally, system authors have a setter and getter for port contents, as well as a callback to allow the system author to avoid regular polling of port contents.

Closes #39