### PR TITLE
feature-timers: initial add

### DIFF
--- a/teenyat.c
+++ b/teenyat.c
@@ -211,6 +211,9 @@ bool tny_reset(teenyat *t) {
 	/* Maybe dont memset? could simulate randomness... */
 	memset(t->interrupt_vector_table, 0, sizeof(t->interrupt_vector_table));
 
+    /* Reset our timers */
+    memset(t->timers, 0, sizeof(t->timers));
+
 	/*
 	 * Initialize each teenyat with a unique random number stream
 	 */
@@ -314,6 +317,61 @@ void tny_set_ports(teenyat *t, tny_word *a, tny_word *b) {
 	return;
 }
 
+void tny_set_timer_pin(teenyat *t, Timer timer, bool value) {
+    t->timers[timer].t_in = value;
+    return;
+}
+
+bool tny_get_timer_pin(teenyat *t, Timer timer) {
+    return t->timers[timer].t_in;
+}
+
+void update_timer(teenyat* t, Timer timer, bool event_triggered) {
+    tny_uword mode = t->timers[timer].csr.timer_csr.mode;
+    if(mode == TIMER_MODE_COUNT || (mode == TIMER_MODE_LEVEL && t->timers[timer].t_in) || event_triggered) {
+        t->timers[timer].count++;
+        /* Trigger an interrupt if the timers value is reached */
+        if(t->timers[timer].count >= t->timers[timer].compare) {
+            tny_uword interrupt_mask = 1 << (timer + TNY_TIMER_A_INT);
+			t->interrupt_queue_register.u |= interrupt_mask;
+        }
+    }
+    return;
+}
+
+void handle_timers(teenyat* t) {
+    for(int i = 0; i < TNY_TOTAL_TIMERS; i++) {
+        bool reset = t->timers[i].csr.timer_csr.reset;
+        bool enabled = t->timers[i].csr.timer_csr.enable;
+        if(reset) {
+            t->timers[i].csr.u   = 0;
+            t->timers[i].compare = 0;
+            t->timers[i].count   = 0;
+        } else if(enabled) {
+            tny_uword  cps   = t->timers[i].csr.timer_csr.clock_prescaler;
+            /* treat a cps of 0 as 1 */
+            if(cps == 0) {
+                cps = 1;
+            }
+            /* update the timers internal clock */
+            t->timers[i].internal_cycle_count++;
+            if(t->timers[i].internal_cycle_count % cps == 0) {
+                update_timer(t, i, false);
+            }
+        }
+    }
+    return;
+}
+
+void tny_trigger_timer_event(teenyat *t, Timer timer) {
+    tny_uword mode = t->timers[timer].csr.timer_csr.mode;
+    tny_uword enable = t->timers[timer].csr.timer_csr.enable;
+    if(enable && mode == TIMER_MODE_EVENT) {
+       update_timer(t, timer, true);
+    }
+    return;
+}
+
 void tny_external_interrupt(teenyat* t, tny_uword external_interrupt) {
 	/*
 	 * Make a mask with a 1 in the position of the external interrupt number
@@ -374,6 +432,9 @@ void tny_clock(teenyat *t) {
 	}
 
 	t->cycle_cnt++;
+
+    /* Timers are seperate pieces of internal hardware uneffected by delay cycles */
+    handle_timers(t);
 
 	/*
 	 * If there were still cycles left on the previous instruction, skip
@@ -465,6 +526,24 @@ void tny_clock(teenyat *t) {
 				case TNY_INTERRUPT_QUEUE_REGISTER:
 					t->reg[reg1] = t->interrupt_queue_register;
 					break;
+                case TNY_TIMER_A_CSR:
+					t->reg[reg1] = t->timers[TNY_TIMER_A].csr;
+                    break;
+                case TNY_TIMER_A_CMP:
+					t->reg[reg1].u = t->timers[TNY_TIMER_A].compare;
+                    break;
+                case TNY_TIMER_A_CNT:
+					t->reg[reg1].u = t->timers[TNY_TIMER_A].count;
+                    break;
+                case TNY_TIMER_B_CSR:
+					t->reg[reg1] = t->timers[TNY_TIMER_B].csr;
+                    break;
+                case TNY_TIMER_B_CMP:
+					t->reg[reg1].u = t->timers[TNY_TIMER_B].compare;
+                    break;
+                case TNY_TIMER_B_CNT:
+					t->reg[reg1].u = t->timers[TNY_TIMER_B].count;
+                    break;
 				default:
 					/* Check if reading from interrupt service */
 					if(addr >= TNY_INTERRUPT_VECTOR_TABLE_START &&
@@ -535,6 +614,24 @@ void tny_clock(teenyat *t) {
 				case TNY_INTERRUPT_QUEUE_REGISTER:
 					t->interrupt_queue_register = t->reg[reg2];
 					break;
+                case TNY_TIMER_A_CSR:
+					t->timers[TNY_TIMER_A].csr = t->reg[reg2];
+                    break;
+                case TNY_TIMER_A_CMP:
+					t->timers[TNY_TIMER_A].compare = t->reg[reg2].u;
+                    break;
+                case TNY_TIMER_A_CNT:
+					t->timers[TNY_TIMER_A].count  = t->reg[reg2].u;
+                    break;
+                case TNY_TIMER_B_CSR:
+					t->timers[TNY_TIMER_B].csr = t->reg[reg2];
+                    break;
+                case TNY_TIMER_B_CMP:
+					t->timers[TNY_TIMER_B].compare = t->reg[reg2].u;
+                    break;
+                case TNY_TIMER_B_CNT:
+				    t->timers[TNY_TIMER_B].count = t->reg[reg2].u;
+                    break;
 				default:
 					/* Check if writing to interrupt service */
 					if(addr >= TNY_INTERRUPT_VECTOR_TABLE_START &&

--- a/teenyat.h
+++ b/teenyat.h
@@ -117,6 +117,15 @@ typedef void(*TNY_PORT_CHANGE_FNPTR)(teenyat *t, bool is_port_a, tny_word port);
 #define TNY_INTERRUPT_ENABLE_REGISTER 0x8E10
 #define TNY_INTERRUPT_QUEUE_REGISTER 0x8E11
 
+#define TNY_TIMER_A_CSR  0x8080
+#define TNY_TIMER_A_CMP  0x8081
+#define TNY_TIMER_A_CNT  0x8082
+
+#define TNY_TIMER_B_CSR  0x8088
+#define TNY_TIMER_B_CMP  0x8089
+#define TNY_TIMER_B_CNT  0x808A
+
+#define TNY_TOTAL_TIMERS 2  // Changing this requires updating the timer addresses above
 
 #define TNY_PERIPHERAL_BASE_ADDRESS 0x9000
 
@@ -136,6 +145,11 @@ typedef struct alu_flags {
 	bool carry   : 1;
 	int reserved: 12;
 } alu_flags;
+
+typedef enum Timer {
+    TIMER_A,
+    TIMER_B
+} Timer;
 
 union tny_word {
 	struct {
@@ -160,6 +174,13 @@ union tny_word {
 		tny_uword interrupt_clearing  : 1;
 		tny_uword reserved : 14;
 	} csr;
+
+    struct {
+      tny_uword clock_prescaler    : 12;
+      tny_uword enable             :  1;
+      tny_uword mode               :  2;
+      tny_uword reset              :  1;
+    } timer_csr;
 
 	struct {
 		tny_uword byte0 : 8;
@@ -287,6 +308,20 @@ struct teenyat {
 	tny_word interrupt_return_address;
 	alu_flags interrupt_return_flags;
 
+    /**
+     * The timers in the teenyAT consist of 3 modes:
+     * Mode 0 (timer mode) --> increments count until CNT >= CMP
+     * Mode 1 (level mode) --> same as Mode 0 however only increments while Tn is high
+     * Mode 2 (event mode) --> increments whenever a system call back was triggered
+     */
+    struct {
+        tny_word  csr;
+        tny_uword compare;
+        tny_uword count;
+        uint64_t  internal_cycle_count;
+        bool      t_in;
+    } timers[TNY_TOTAL_TIMERS];
+
 	/**
 	 * Each teenyat instance has a unique random number generator stream,
 	 * seeded at initialization.  These are using the PCG-XSH-RR with a 64-bit
@@ -376,6 +411,17 @@ struct teenyat {
 #define TNY_XINT5    5
 #define TNY_XINT6    6
 #define TNY_XINT7    7
+
+#define TNY_TIMER_A         0
+#define TNY_TIMER_B         1
+
+#define TIMER_MODE_COUNT    0
+#define TIMER_MODE_LEVEL    1
+#define TIMER_MODE_EVENT    2
+
+#define TNY_TIMER_A_INT     6
+#define TNY_TIMER_B_INT     7
+
 
 /**
  * @brief
@@ -589,6 +635,49 @@ void tny_port_change(teenyat *t, TNY_PORT_CHANGE_FNPTR port_change);
  *   A number from 0-7 denoting which external interrupt to queue
  */
 void tny_external_interrupt(teenyat* t, tny_uword external_interrupt);
+
+/**
+ * @brief
+ *   Sets the level of the associated timer's pin
+ *
+ *   While a timer is in level mode (1), the count
+ *   will increment if this pin is high otherwise
+ *   the count is unchanged
+ *
+ * @param t
+ *   The TeenyAT instance
+ *
+ * @param timer
+ *   The timer to modify
+ *
+ * @param value
+ *   The value to set the pin to
+ */
+void tny_set_timer_pin(teenyat *t, Timer timer, bool value);
+
+/**
+ * @brief
+ *   Gets the level of the associated timer's pin
+ *
+ * @param t
+ *   The TeenyAT instance
+ *
+ * @param timer
+ *   The timer to access
+ */
+bool tny_get_timer_pin(teenyat *t, Timer timer);
+
+/**
+ * @brief
+ *   Triggers a timer and increments its value if in event mode
+ *
+ * @param t
+ *   The TeenyAT instance
+ *
+ * @param timer
+ *   The timer we are looking to increment
+ */
+void tny_trigger_timer_event(teenyat *t, Timer timer);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Added the functionality for dedicated timers within the teenyAT microprocessor. Timers will enable more responsive systesm as we can now track clock cycles while preforming other instructions and have our code become interrupted when timers go off through interrupts.