### PR TITLE
Feature timers

### DIFF
--- a/edison/asm/example_timers_event_mode.asm
+++ b/edison/asm/example_timers_event_mode.asm
@@ -1,0 +1,128 @@
+;---------------------------------------------------------
+; Simple demonstration of the use of timers in EVENT mode.
+; The program sets up an interrupt handler for Timer A that
+; that will go off every time a key is pressed/released (not held)
+;
+;       TIMER CONTROL STATUS REGISTER ENCODING
+;                0b0_00_0_000000000000
+;
+;           bit0 -> bit11  : Clock Prescaler (how many cycles until we increment the count?)
+;           bit12          : Clock Enable    (should we run the timer)
+;           bit13 -> bit14 : Clock Mode      (0->Count, 1->Level, 2->Event)
+;           bit15          : Clock Reset     (sets the clocks csr, cmp and cnt to zero)
+;
+; In the teenyAT Edison Experiment Board Timer A is hooked up to track the key
+; presses in the experiment board
+
+; TeenyAT Constants
+.const PORT_A_DIR                0x8000
+.const PORT_B_DIR                0x8001
+.const PORT_A                    0x8002
+.const PORT_B                    0x8003
+
+.const RAND                      0x8010
+.const RAND_BITS                 0x8011
+
+.const TIMER_A_CSR               0x8080
+.const TIMER_A_CMP               0x8081
+.const TIMER_A_CNT               0x8082
+.const TIMER_B_CSR               0x8088
+.const TIMER_B_CMP               0x8089
+.const TIMER_B_CNT               0x808A
+
+.const INTERRUPT_VECTOR_TABLE    0x8E00
+.const INTERRUPT_ENABLE_REGISTER 0x8E10
+
+.const CONTROL_STATUS_REGISTER   0x8EFF
+
+; Edison Constants
+.const LCD_CURSOR           0xA000
+.const LCD_CLEAR_SCREEN     0xA001
+.const LCD_MOVE_LEFT        0xA002
+.const LCD_MOVE_RIGHT       0xA003
+.const LCD_MOVE_UP          0xA004
+.const LCD_MOVE_DOWN        0xA005
+.const LCD_MOVE_LEFT_WRAP   0xA006
+.const LCD_MOVE_RIGHT_WRAP  0xA007
+.const LCD_MOVE_UP_WRAP     0xA008
+.const LCD_MOVE_DOWN_WRAP   0xA009
+.const LCD_CURSOR_X         0xA00A
+.const LCD_CURSOR_Y         0xA00B
+.const LCD_CURSOR_XY        0xA00C
+.const BUZZER_LEFT          0xA010
+.const BUZZER_RIGHT         0xA011
+.const FADER_LEFT           0xA020
+.const FADER_RIGHT          0xA021
+
+; Set up interrupt callbacks for Timers A
+    set rA, !timer_A_callback
+    set rB, 6
+    str [ INTERRUPT_VECTOR_TABLE + rB ], rA
+
+; Enable internal interrupts 6 ( Timers A )
+    set rA, rZ
+    bts rA, 6
+    str [ INTERRUPT_ENABLE_REGISTER ], rA
+
+; Enable interrupts globally
+    set rA, rZ
+    bts rA, 0
+    str [ CONTROL_STATUS_REGISTER ], rA
+
+;---------- Timer Setup ----------------
+; By setting our comparison to 1 we can have the timer go off
+; every time it receives an event trigger
+
+; Timer A will go off once for every initial key press
+    set rA, 1
+    str [ TIMER_A_CMP ], rA
+    set rA, rZ
+    bts rA, 14               ; setting bit 14 puts our timer into EVENT mode
+    bts rA, 12               ; enable our timer (bit12)
+    str [ TIMER_A_CSR ], rA
+
+;---------- Main Loop --------------------
+; Register A holds the count of key presses/releases
+    set rA, rZ
+    str [ PORT_B_DIR ], rZ      ; all outputs
+
+    str [ LCD_CURSOR_XY ], rZ
+    set rC, !info1
+    cal !print_string_rC
+    set rC, !info2
+    cal !print_string_rC
+
+!main
+    ; All updates are handled by interrupts
+    jmp !main
+
+;---------- Interrupt Callbacks ----------
+!timer_A_callback
+    inc rA
+    str [ PORT_B ], rA
+    str [ TIMER_A_CNT ], rZ     ; reset our timer
+    rti
+
+;--------- String Printing Function ------------
+; Prints characters in a string pointed to by register C
+!print_string_rC
+    psh rA
+    psh rC
+!print_string_rC_loop
+    lod rA, [rC]
+    cmp rA, rZ
+    je !print_string_rC_return
+    str [ LCD_CURSOR ], rA
+    inc rC
+    jmp !print_string_rC_loop
+!print_string_rC_return
+    pop rC
+    pop rA
+    ret
+
+;--------- Data ----------------
+!info1
+.raw "Counts Key Presses"
+
+!info2
+.raw '\n' '\r' "and Key Releases!"

--- a/edison/asm/example_timers_level_mode.asm
+++ b/edison/asm/example_timers_level_mode.asm
@@ -1,0 +1,153 @@
+;---------------------------------------------------------
+; Simple demonstration of the use of timers in LEVEL mode.
+; The program sets up an interrupt handler for Timer A & Timer B
+; that will go off every second provided the associated level pin
+; is HIGH
+;
+;       TIMER CONTROL STATUS REGISTER ENCODING
+;                0b0_00_0_000000000000
+;
+;           bit0 -> bit11  : Clock Prescaler (how many cycles until we increment the count?)
+;           bit12          : Clock Enable    (should we run the timer)
+;           bit13 -> bit14 : Clock Mode      (0->Count, 1->Level, 2->Event)
+;           bit15          : Clock Reset     (sets the clocks csr, cmp and cnt to zero)
+;
+; In the teenyAT Edison Experiment Board Timer A's level pin is linked to
+; the pressing of the left arrow key while Timer B's pin is linked to the
+; pressing of the right arrow key
+
+; TeenyAT Constants
+.const PORT_A_DIR                0x8000
+.const PORT_B_DIR                0x8001
+.const PORT_A                    0x8002
+.const PORT_B                    0x8003
+
+.const RAND                      0x8010
+.const RAND_BITS                 0x8011
+
+.const TIMER_A_CSR               0x8080
+.const TIMER_A_CMP               0x8081
+.const TIMER_A_CNT               0x8082
+.const TIMER_B_CSR               0x8088
+.const TIMER_B_CMP               0x8089
+.const TIMER_B_CNT               0x808A
+
+.const INTERRUPT_VECTOR_TABLE    0x8E00
+.const INTERRUPT_ENABLE_REGISTER 0x8E10
+
+.const CONTROL_STATUS_REGISTER   0x8EFF
+
+; Edison Constants
+.const LCD_CURSOR           0xA000
+.const LCD_CLEAR_SCREEN     0xA001
+.const LCD_MOVE_LEFT        0xA002
+.const LCD_MOVE_RIGHT       0xA003
+.const LCD_MOVE_UP          0xA004
+.const LCD_MOVE_DOWN        0xA005
+.const LCD_MOVE_LEFT_WRAP   0xA006
+.const LCD_MOVE_RIGHT_WRAP  0xA007
+.const LCD_MOVE_UP_WRAP     0xA008
+.const LCD_MOVE_DOWN_WRAP   0xA009
+.const LCD_CURSOR_X         0xA00A
+.const LCD_CURSOR_Y         0xA00B
+.const LCD_CURSOR_XY        0xA00C
+.const BUZZER_LEFT          0xA010
+.const BUZZER_RIGHT         0xA011
+.const FADER_LEFT           0xA020
+.const FADER_RIGHT          0xA021
+
+; Set up interrupt callbacks for Timers A and B
+    set rA, !timer_A_callback
+    set rB, 6
+    str [ INTERRUPT_VECTOR_TABLE + rB ], rA
+
+    inc rB
+    set rA, !timer_B_callback
+    str [ INTERRUPT_VECTOR_TABLE + rB ], rA
+
+; Enable internal interrupts 6 & 7 ( Timers A and B respectively)
+    set rA, rZ
+    bts rA, 6
+    bts rA, 7
+    str [ INTERRUPT_ENABLE_REGISTER ], rA
+
+; Enable interrupts globally
+    set rA, rZ
+    bts rA, 0
+    str [ CONTROL_STATUS_REGISTER ], rA
+
+;---------- Timer Setup ----------------
+; Given a 1mhz clock rate the math Im using to activate our timer every second is
+; (1,000,000 / 65535) ~= 15
+; This means we need a clock prescaler of 15 or in other words increment our timer once every 15 cycles
+
+; Timer A will go off once every second the left arrow is pressed
+    set rA, 65535
+    str [ TIMER_A_CMP ], rA
+    set rA, 15               ; set our cps to be 15
+    bts rA, 13               ; setting bit 13 puts our timer into LEVEL mode
+    bts rA, 12               ; enable our timer (bit12)
+    str [ TIMER_A_CSR ], rA
+
+; Timer B will go off every second the right arrow is pressed
+    set rA, 65535
+    str [ TIMER_B_CMP ], rA
+    set rA, 15               ; set our cps to be 15
+    bts rA, 13               ; setting bit 13 puts our timer into LEVEL mode
+    bts rA, 12               ; enable our timer (bit12)
+    str [ TIMER_B_CSR ], rA
+
+;---------- Main Loop --------------------
+; Register A holds the count of seconds passed in Timer A
+; Register B holds the count of seconds passed in Timer B
+    set rA, rZ
+    set rB, rZ
+    str [ PORT_A_DIR ], rZ      ; all outputs
+    str [ PORT_B_DIR ], rZ      ; all outputs
+
+    str [ LCD_CURSOR_XY ], rZ
+    set rC, !info1
+    cal !print_string_rC
+    set rC, !info2
+    cal !print_string_rC
+
+!main
+    ; All updates are handled by interrupts
+    jmp !main
+
+;---------- Interrupt Callbacks ----------
+!timer_A_callback
+    inc rA
+    str [ PORT_B ], rA
+    str [ TIMER_A_CNT ], rZ     ; reset our timer
+    rti
+
+!timer_B_callback
+    inc rB
+    str [ PORT_A ], rB
+    str [ TIMER_B_CNT ], rZ     ; reset our timer
+    rti
+
+;--------- String Printing Function ------------
+; Prints characters in a string pointed to by register C
+!print_string_rC
+    psh rA
+    psh rC
+!print_string_rC_loop
+    lod rA, [rC]
+    cmp rA, rZ
+    je !print_string_rC_return
+    str [ LCD_CURSOR ], rA
+    inc rC
+    jmp !print_string_rC_loop
+!print_string_rC_return
+    pop rC
+    pop rA
+    ret
+
+;--------- Data ----------------
+!info1
+.raw "Timers Rock!"
+
+!info2
+.raw '\n' '\n' '\r' "Hold Arrows <- ->"

--- a/edison/asm/example_timers_level_mode.asm
+++ b/edison/asm/example_timers_level_mode.asm
@@ -78,21 +78,21 @@
 
 ;---------- Timer Setup ----------------
 ; Given a 1mhz clock rate the math Im using to activate our timer every second is
-; (1,000,000 / 65535) ~= 15
-; This means we need a clock prescaler of 15 or in other words increment our timer once every 15 cycles
+; (1,000,000 / 50,000) = 20
+; This means we need a clock prescaler of 20 or in other words increment our timer once every 20 cycles
 
 ; Timer A will go off once every second the left arrow is pressed
-    set rA, 65535
+    set rA, 50000
     str [ TIMER_A_CMP ], rA
-    set rA, 15               ; set our cps to be 15
+    set rA, 20               ; set our cps to be 20
     bts rA, 13               ; setting bit 13 puts our timer into LEVEL mode
     bts rA, 12               ; enable our timer (bit12)
     str [ TIMER_A_CSR ], rA
 
 ; Timer B will go off every second the right arrow is pressed
-    set rA, 65535
+    set rA, 50000
     str [ TIMER_B_CMP ], rA
-    set rA, 15               ; set our cps to be 15
+    set rA, 20               ; set our cps to be 20
     bts rA, 13               ; setting bit 13 puts our timer into LEVEL mode
     bts rA, 12               ; enable our timer (bit12)
     str [ TIMER_B_CSR ], rA

--- a/edison/asm/example_timers_timer_mode.asm
+++ b/edison/asm/example_timers_timer_mode.asm
@@ -1,0 +1,146 @@
+;---------------------------------------------------------
+; Simple demonstration of the use of timers in TIMER mode.
+; The program sets up an interrupt handler for Timer A & Timer B
+; that will go off every second and half-second respectively
+;
+;       TIMER CONTROL STATUS REGISTER ENCODING
+;                0b0_00_0_000000000000
+;
+;           bit0 -> bit11  : Clock Prescaler (how many cycles until we increment the count?)
+;           bit12          : Clock Enable    (should we run the timer)
+;           bit13 -> bit14 : Clock Mode      (0->Count, 1->Level, 2->Event)
+;           bit15          : Clock Reset     (sets the clocks csr, cmp and cnt to zero)
+
+; TeenyAT Constants
+.const PORT_A_DIR                0x8000
+.const PORT_B_DIR                0x8001
+.const PORT_A                    0x8002
+.const PORT_B                    0x8003
+
+.const RAND                      0x8010
+.const RAND_BITS                 0x8011
+
+.const TIMER_A_CSR               0x8080
+.const TIMER_A_CMP               0x8081
+.const TIMER_A_CNT               0x8082
+.const TIMER_B_CSR               0x8088
+.const TIMER_B_CMP               0x8089
+.const TIMER_B_CNT               0x808A
+
+.const INTERRUPT_VECTOR_TABLE    0x8E00
+.const INTERRUPT_ENABLE_REGISTER 0x8E10
+
+.const CONTROL_STATUS_REGISTER   0x8EFF
+
+; Edison Constants
+.const LCD_CURSOR           0xA000
+.const LCD_CLEAR_SCREEN     0xA001
+.const LCD_MOVE_LEFT        0xA002
+.const LCD_MOVE_RIGHT       0xA003
+.const LCD_MOVE_UP          0xA004
+.const LCD_MOVE_DOWN        0xA005
+.const LCD_MOVE_LEFT_WRAP   0xA006
+.const LCD_MOVE_RIGHT_WRAP  0xA007
+.const LCD_MOVE_UP_WRAP     0xA008
+.const LCD_MOVE_DOWN_WRAP   0xA009
+.const LCD_CURSOR_X         0xA00A
+.const LCD_CURSOR_Y         0xA00B
+.const LCD_CURSOR_XY        0xA00C
+.const BUZZER_LEFT          0xA010
+.const BUZZER_RIGHT         0xA011
+.const FADER_LEFT           0xA020
+.const FADER_RIGHT          0xA021
+
+; Set up interrupt callbacks for Timers A and B
+    set rA, !timer_A_callback
+    set rB, 6
+    str [ INTERRUPT_VECTOR_TABLE + rB ], rA
+
+    inc rB
+    set rA, !timer_B_callback
+    str [ INTERRUPT_VECTOR_TABLE + rB ], rA
+
+; Enable internal interrupts 6 & 7 ( Timers A and B respectively)
+    set rA, rZ
+    bts rA, 6
+    bts rA, 7
+    str [ INTERRUPT_ENABLE_REGISTER ], rA
+
+; Enable interrupts globally
+    set rA, rZ
+    bts rA, 0
+    str [ CONTROL_STATUS_REGISTER ], rA
+
+;---------- Timer Setup ----------------
+; Given a 1mhz clock rate the math Im using to activate our timer every second is
+; (1,000,000 / 65535) ~= 15
+; This means we need a clock prescaler of 15 or in other words increment our timer once every 15 cycles
+
+; Timer A will go off once every second
+    set rA, 65535
+    str [ TIMER_A_CMP ], rA
+    set rA, 15               ; set our cps to be 15
+    bts rA, 12               ; enable our timer (bit12)
+    str [ TIMER_A_CSR ], rA
+
+; Timer B will go off every half a second
+    set rA, 65535
+    str [ TIMER_B_CMP ], rA
+    set rA, 7                ; set our cps to be 7 ( about half of 15 )
+    bts rA, 12               ; enable our timer (bit12)
+    str [ TIMER_B_CSR ], rA
+
+;---------- Main Loop --------------------
+; Register A holds the count of seconds passed in Timer A
+; Register B holds the count of seconds passed in Timer B
+    set rA, rZ
+    set rB, rZ
+    str [ PORT_A_DIR ], rZ      ; all outputs
+    str [ PORT_B_DIR ], rZ      ; all outputs
+
+    str [ LCD_CURSOR_XY ], rZ
+    set rC, !info1
+    cal !print_string_rC
+    set rC, !info2
+    cal !print_string_rC
+
+!main
+    ; All updates are handled by interrupts
+    jmp !main
+
+;---------- Interrupt Callbacks ----------
+!timer_A_callback
+    inc rA
+    str [ PORT_B ], rA
+    str [ TIMER_A_CNT ], rZ     ; reset our timer
+    rti
+
+!timer_B_callback
+    inc rB
+    str [ PORT_A ], rB
+    str [ TIMER_B_CNT ], rZ
+    rti
+
+;--------- String Printing Function ------------
+; Prints characters in a string pointed to by register C
+!print_string_rC
+    psh rA
+    psh rC
+!print_string_rC_loop
+    lod rA, [rC]
+    cmp rA, rZ
+    je !print_string_rC_return
+    str [ LCD_CURSOR ], rA
+    inc rC
+    jmp !print_string_rC_loop
+!print_string_rC_return
+    pop rC
+    pop rA
+    ret
+
+;--------- Data ----------------
+!info1
+.raw "7-seg 2 counts secs"
+
+!info2
+.raw '\n' '\n' '\r' "7-seg 1 is half secs"

--- a/edison/asm/example_timers_timer_mode.asm
+++ b/edison/asm/example_timers_timer_mode.asm
@@ -73,21 +73,21 @@
 
 ;---------- Timer Setup ----------------
 ; Given a 1mhz clock rate the math Im using to activate our timer every second is
-; (1,000,000 / 65535) ~= 15
-; This means we need a clock prescaler of 15 or in other words increment our timer once every 15 cycles
+; (1,000,000 / 50,000) = 20
+; This means we need a clock prescaler of 20 or in other words increment our timer once every 20 cycles
 
 ; Timer A will go off once every second
-    set rA, 65535
+    set rA, 50000
     str [ TIMER_A_CMP ], rA
-    set rA, 15               ; set our cps to be 15
+    set rA, 20               ; set our cps to be 20
     bts rA, 12               ; enable our timer (bit12)
     str [ TIMER_A_CSR ], rA
 
 ; Timer B will go off every half a second
-    set rA, 65535
+    set rA, 50000
     str [ TIMER_B_CMP ], rA
-    set rA, 7                ; set our cps to be 7 ( about half of 15 )
-    bts rA, 12               ; enable our timer (bit12)
+    set rA, 10                ; set our cps to be 10 ( half of 20 )
+    bts rA, 12                ; enable our timer (bit12)
     str [ TIMER_B_CSR ], rA
 
 ;---------- Main Loop --------------------

--- a/edison/edison_board.cpp
+++ b/edison/edison_board.cpp
@@ -322,6 +322,9 @@ void process_keyboard(teenyat* t){
         render_dip_switches();
         render_push_buttons(&inp_keyboard);
         led_array_draw(t);   
+        tny_trigger_timer_event(t, TNY_TIMER_A);
+        tny_set_timer_pin(t,TNY_TIMER_A,inp_keyboard.bits.bit0);
+        tny_set_timer_pin(t,TNY_TIMER_B,inp_keyboard.bits.bit2);
     }
 
     old_keyboard.u = inp_keyboard.u;

--- a/teenyat.h
+++ b/teenyat.h
@@ -120,6 +120,15 @@ typedef void(*TNY_PORT_CHANGE_FNPTR)(teenyat *t, bool is_port_a, tny_word port);
 #define TNY_INTERRUPT_ENABLE_REGISTER 0x8E10
 #define TNY_INTERRUPT_QUEUE_REGISTER 0x8E11
 
+#define TNY_TIMER_A_CSR  0x8080
+#define TNY_TIMER_A_CMP  0x8081
+#define TNY_TIMER_A_CNT  0x8082
+
+#define TNY_TIMER_B_CSR  0x8088
+#define TNY_TIMER_B_CMP  0x8089
+#define TNY_TIMER_B_CNT  0x808A
+
+#define TNY_TOTAL_TIMERS 2  // Changing this requires updating the timer addresses above
 
 #define TNY_PERIPHERAL_BASE_ADDRESS 0x9000
 
@@ -151,6 +160,11 @@ typedef enum tny_xint {
     TNY_XINT7
 } tny_xint;
 
+typedef enum Timer {
+    TNY_TIMER_A,
+    TNY_TIMER_B
+} Timer;
+
 union tny_word {
 	struct {
 		tny_sword immed4  : 4;
@@ -176,6 +190,13 @@ union tny_word {
 		tny_uword unclocked : 1;
 		tny_uword reserved : 9;
 	} csr;
+
+    struct {
+      tny_uword clock_prescaler    : 12;
+      tny_uword enable             :  1;
+      tny_uword mode               :  2;
+      tny_uword reset              :  1;
+    } timer_csr;
 
 	struct {
 		tny_uword byte0 : 8;
@@ -303,6 +324,20 @@ struct teenyat {
 	tny_word interrupt_return_address;
 	alu_flags interrupt_return_flags;
 
+    /**
+     * The timers in the teenyAT consist of 3 modes:
+     * Mode 0 (timer mode) --> increments count until CNT >= CMP
+     * Mode 1 (level mode) --> same as Mode 0 however only increments while Tn is high
+     * Mode 2 (event mode) --> increments whenever a system call back was triggered
+     */
+    struct {
+        tny_word  csr;
+        tny_uword compare;
+        tny_uword count;
+        uint64_t  internal_cycle_count;
+        bool      t_in;
+    } timers[TNY_TOTAL_TIMERS];
+
 	/**
 	 * Each teenyat instance has a unique random number generator stream,
 	 * seeded at initialization.  These are using the PCG-XSH-RR with a 64-bit
@@ -390,6 +425,13 @@ struct teenyat {
 #define TNY_REG_C    5
 #define TNY_REG_D    6
 #define TNY_REG_E    7
+
+#define TIMER_MODE_COUNT    0
+#define TIMER_MODE_LEVEL    1
+#define TIMER_MODE_EVENT    2
+
+#define TNY_TIMER_A_INT     6
+#define TNY_TIMER_B_INT     7
 
 /**
  * @brief
@@ -548,6 +590,49 @@ void tny_port_change(teenyat *t, TNY_PORT_CHANGE_FNPTR port_change);
  *   A number from 0-7 denoting which external interrupt to queue
  */
 void tny_external_interrupt(teenyat* t, tny_xint external_interrupt);
+
+/**
+ * @brief
+ *   Sets the level of the associated timer's pin
+ *
+ *   While a timer is in level mode (1), the count
+ *   will increment if this pin is high otherwise
+ *   the count is unchanged
+ *
+ * @param t
+ *   The TeenyAT instance
+ *
+ * @param timer
+ *   The timer to modify
+ *
+ * @param value
+ *   The value to set the pin to
+ */
+void tny_set_timer_pin(teenyat *t, Timer timer, bool value);
+
+/**
+ * @brief
+ *   Gets the level of the associated timer's pin
+ *
+ * @param t
+ *   The TeenyAT instance
+ *
+ * @param timer
+ *   The timer to access
+ */
+bool tny_get_timer_pin(teenyat *t, Timer timer);
+
+/**
+ * @brief
+ *   Triggers a timer and increments its value if in event mode
+ *
+ * @param t
+ *   The TeenyAT instance
+ *
+ * @param timer
+ *   The timer we are looking to increment
+ */
+void tny_trigger_timer_event(teenyat *t, Timer timer);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Added internal hardware timers to the teenyAT! Having timers will allow assembly writers to track certain events and trigger unique program behavior as a result all while running other code. Set it and forget it!