### PR TITLE
teenyat.h: fix cpp guards drop cstdint

### DIFF
--- a/teenyat.h
+++ b/teenyat.h
@@ -8,17 +8,14 @@
 #ifndef __TEENYAT_H__
 #define __TEENYAT_H__
 
-#ifndef __cplusplus
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif /* __cplusplus */
 
 #include <stdbool.h>
 #include <stdint.h>
-
-#else  /* __cplusplus */
-extern "C" {
-
-#include <cstdint>
-
-#endif /* __cplusplus */
 
 typedef struct teenyat teenyat;
 


### PR DESCRIPTION
No need to use C++'s cstdint in a C header file for inclusion into a C++ project, just extern declaration the functions and headers so the C++ name mangler knows and doesn't mangle them. Then this will work between the two languages without a problem and simplify the header file.