### PR TITLE
Fixed bug where certain jump instructions would be encoded as teeny

### DIFF
--- a/tnasm/parser.cpp
+++ b/tnasm/parser.cpp
@@ -1171,7 +1171,7 @@ bool p_code_13_line() {
 
         tny_word &f = inst.first;
         f.instruction.opcode = token_to_opcode(oper->id);
-        f.instruction.teeny = 1;
+        f.instruction.teeny = 0;  // jump instructions can never be teeny
         f.instruction.reg1 = sreg->value.u;
         f.instruction.reg2 = 0;
 
@@ -1189,10 +1189,13 @@ bool p_code_13_line() {
             f.inst_flags.carry = 1;
         }
 
-        address++;
+        inst.second.s = 0;
+
+        address+=2;
 
         if(pass > 1) {
             bin_words.push_back(f);
+            bin_words.push_back(inst.second);
         }
 
         result = true;

--- a/tnasm/test.asm
+++ b/tnasm/test.asm
@@ -25,7 +25,7 @@
     inc r2              ;1
     dec r2              ;1
     str [r4 + 16], r3     ;2
-    jmp r3              ;1
+    jmp r3              ;2
     ret                 ;1
     psh 5              ;1
     psh -20              ;2


### PR DESCRIPTION
A jump instruction provided with only a register as its operand was being encoded as teeny since the immediate to add is just zero. This is incorrect because the immed4 field for a jump instruction holds the flags to be checked before we preform a jump.

resolves issue #75