### PR TITLE
Initializing the SP to TNY_MAX_RAM_ADDRESS

### DIFF
--- a/teenyat.c
+++ b/teenyat.c
@@ -193,7 +193,7 @@ bool tny_reset(teenyat *t) {
 	memcpy(t->ram, t->bin_image, TNY_RAM_SIZE * sizeof(tny_word));
 
 	t->reg[TNY_REG_PC].u = 0x0;
-	t->reg[TNY_REG_SP].u = 0x7FFF;
+	t->reg[TNY_REG_SP].u = TNY_MAX_RAM_ADDRESS;
 	t->reg[TNY_REG_ZERO].u = 0;
 	t->reg[TNY_REG_A].u = 0;
 	t->reg[TNY_REG_B].u = 0;


### PR DESCRIPTION
In teenyat.c, the tny_reset() function initializes the SP to 0x7FFF, when there is a variable TNY_MAX_RAM_ADDRESS defined in teenyat.h which is set to 0x7FFF. Making this change allows the max ram address to be changed without breaking the tny_reset() function.